### PR TITLE
Make extension signing compatible with current Safari releases

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@
 //  http://www.avast.com
 //
 //  Packs Safari extensions without interacting with the browser.
-//  Works on MacOS, Linux and Windows, as long as you have xar 1.6.1 and openssl installed and in path.
-//  Neither xar 1.5 nor 1.7 will work, as they don't support the --sign option
+//  Works on MacOS, Linux and Windows. Requires a fork of the 'xar' utility
+//  with signature support from https://github.com/robertknight/xar/releases/tag/xar-1.6.1.1
+//  and 'openssl' installed and in the PATH.
+//
+//  Note that the version of 'xar' shipped with OS X does not support
+//  the --sign option.
 
 (function () {
     'use strict';
@@ -29,7 +33,6 @@
             delete options['hide_stdout'];
         }
 
-        //console.log(command);
         return when.promise(function (resolve, reject) {
             execute(command, options, function (err, stdout, stderr) {
                 if (!hide_stdout && stdout) {
@@ -67,26 +70,47 @@
             temp = "";
         }
 
-        return exec('xar -cf ' + safariextzName + ' -C ' + path.dirname(safariextensionDir) + ' ' + path.basename(safariextensionDir))
+	var leafCertArg = '--cert-loc';
+	var intCertArg = '--cert-loc';
+	var rootCertArg = '--cert-loc';
+
+        return exec('xar -cf ' + safariextzName + ' ' + ' -C ' + path.dirname(safariextensionDir) + ' ' + path.basename(safariextensionDir))
             .then(function () {
-                // find out the signature size by siging anything (in this case the key itself)
+                // find out the signature size by signing anything (in this case the key itself)
                 return exec('openssl dgst -sign ' + options.privateKey + ' -binary ' + options.privateKey, { hide_stdout: true, encoding: 'binary' });
             })
             .then(function (signature_buffer) {
-                return exec('xar --sign -f ' + safariextzName + ' --data-to-sign ' + path.join(temp, 'digest.dat') + ' --sig-size ' + signature_buffer.length +
-                     ' --cert-loc ' + options.extensionCer +
-                     ' --cert-loc ' + options.appleDevCer +
-                     ' --cert-loc ' + options.appleRootCer);
+		// add signature metadata, including the type/size/offset and certificate chain
+		// to the xar archive's table of contents and
+		// reserve space in the archive's data section (heap) for the real
+		// signature
+                return exec('xar --replace-sign -f ' + safariextzName + ' --data-to-sign ' + path.join(temp, 'digest.dat') + ' --sig-size ' + signature_buffer.length +
+                     ' ' + leafCertArg + ' ' + options.extensionCer +
+                     ' ' + intCertArg + ' ' + options.appleDevCer +
+                     ' ' + rootCertArg + ' ' + options.appleRootCer);
+            })
+	    .then(function () {
+		// extract compressed table of contents
+		return exec('xar --dump-toc-raw=' + path.join(temp, 'toc.dat') + ' -f ' + safariextzName);
+	    })
+            .then(function () {
+		// sign the compressed table of contents
+		return exec('openssl dgst -sha1 -sign ' + options.privateKey + ' ' + path.join(temp, 'toc.dat'),
+		             {hide_stdout: true, encoding: 'binary'});
+            })
+            .then(function (signature) {
+		// inject the signature back into the xar archive
+		var sigFile = path.join(temp, 'signature.dat');
+		fs.writeFileSync(sigFile, signature, {encoding:'binary'});
+                return exec('xar --inject-sig ' + sigFile + ' -f ' + safariextzName);
             })
             .then(function () {
-                return exec('openssl rsautl -sign -inkey ' + options.privateKey + ' -in ' + path.join(temp, 'digest.dat') + ' -out ' + path.join(temp, 'signature.dat'));
-            })
-            .then(function () {
-                return exec('xar --inject-sig ' + path.join(temp, 'signature.dat') + ' -f ' + safariextzName);
-            })
-            .then(function () {
-                fs.unlink(path.join(temp, 'signature.dat'));
-                fs.unlink(path.join(temp, 'digest.dat'));
+		var tempFiles = ['signature.dat', 'digest.dat', 'toc.dat'].map(function(name) {
+		  return path.join(temp, name);
+		});
+		tempFiles.forEach(function(tempFile) {
+		  fs.unlinkSync(tempFile);
+		});
             });
     }
 


### PR DESCRIPTION
Sign the compressed table of contents in the xar archive
using 'openssl dgst -sign' rather than 'openssl rsautl -sign'.

See https://github.com/avast/safariextz/issues/1#issuecomment-131229944
and the linked StackOverflow post at http://stackoverflow.com/a/16264508
for an explanation of the difference.

This requires an update to xar from
https://github.com/robertknight/xar/commit/847103b787cfddf200c61d7d93fb57f993bdd976
that fixes the --dump-toc-raw option.
